### PR TITLE
fix: allow multi-relative paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # Changelog
 
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v2.2.1" target="_blank">v2.2.1</a> - 2021-09-15
+### Fixed
+- Allow multi-relative paths (Example: 'c:\a\b\x..\c\y\z....\d' -> 'c:\a\b\c\d')
+
 ## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v2.2.0" target="_blank">v2.2.0</a> - 2021-09-15
 ### Changed
 - Make script compatible with PowerShell Core 7.x on Windows (Linux and MacOS are not supported yet)

--- a/docs/README.md
+++ b/docs/README.md
@@ -155,9 +155,14 @@ WebDAV paths are supported (https only): `'https://server.domain/User/Outlook si
 
 The currently logged on user needs at least write access to the path.
 
+If the folder or folder structure does not exist, it is created.
+
 Default value: `"$([environment]::GetFolderPath("MyDocuments"))\Outlook signatures"`  
 ## 2.9. AdditionalSignaturePathFolder
-A folder or folder structure below AdditionalSignaturePath.  
+A folder or folder structure below AdditionalSignaturePath.
+
+This parameter is available for compatibility with versions before 2.2.1. Starting with 2.2.1, you can pass a full path via the parameter AdditionalSignaturePath, so AdditionalSignaturePathFolder is no longer needed.
+
 If the folder or folder structure does not exist, it is created.
 
 Default value: `'Outlook signatures'`  


### PR DESCRIPTION
Example: 'c:\a\b\x\..\c\y\z\..\..\d' -> 'c:\a\b\c\d'