### PR TITLE
v3.3.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.x.x" target="_blank">v3.x.x</a> - YYYY-MM-DD
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha1" target="_blank">v3.3.0-alpha1</a> - 2022-16-08
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
 ### Changed
 - Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha3" target="_blank">v3.3.0-alpha3</a> - 2022-08-20
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha3" target="_blank">v3.3.0</a> - 2022-09-05
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
 ### Changed
 - Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha1" target="_blank">v3.3.0-alpha1</a> - 2022-08-16
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha2" target="_blank">v3.3.0-alpha2</a> - 2022-08-19
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
 ### Changed
 - Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,13 @@
   ### Fixed
 -->
 
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.x.x" target="_blank">v3.x.x</a> - YYYY-MM-DD
+_Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
+### Changed
+- Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"
+### Added
+- New parameter '`SignaturesForAutomappedAndAdditionalMailboxes`' allow deploying signatures not only for primary mailboxes configured in Outlook, but also for automapped and additional mailboxes. See '`README`' for details.
+
 ## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.2.2" target="_blank">v3.2.2</a> - 2022-08-12
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha2" target="_blank">v3.3.0-alpha2</a> - 2022-08-19
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha3" target="_blank">v3.3.0-alpha3</a> - 2022-08-20
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
 ### Changed
 - Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ _Attention cloud mailbox users: Microsoft will make roaming signatures available
 ### Changed
 - Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"
 ### Added
-- New parameter '`SignaturesForAutomappedAndAdditionalMailboxes`' allow deploying signatures not only for primary mailboxes configured in Outlook, but also for automapped and additional mailboxes. See '`README`' for details.
+- The script now detects not only primary mailboxes configured in Outlook, but also automapped and additional mailboxes. This behavior can be disabled with the new parameter '`SignaturesForAutomappedAndAdditionalMailboxes`'. See '`README`' for details.
 
 ## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.2.2" target="_blank">v3.2.2</a> - 2022-08-12
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha1" target="_blank">v3.3.0-alpha1</a> - 2022-16-08
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha1" target="_blank">v3.3.0-alpha1</a> - 2022-08-16
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
 ### Changed
 - Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha3" target="_blank">v3.3.0</a> - 2022-09-05
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0" target="_blank">v3.3.0</a> - 2022-09-05
 _Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
 ### Changed
 - Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"

--- a/docs/README.md
+++ b/docs/README.md
@@ -299,6 +299,14 @@ Outlook 2013 and earlier can't handle these embedded images when composing HTML 
 When setting EmbedImagesInHtml to `$false`, consider setting the Outlook registry value "Send Pictures With Document" to 1 to ensure that images are sent to the recipient (see https://support.microsoft.com/en-us/topic/inline-images-may-display-as-a-red-x-in-outlook-704ae8b5-b9b6-d784-2bdf-ffd96050dfd6 for details).
 
 Default value: `$true`
+## SignaturesForAutomappedAndAdditionalMailboxes
+Deploy signatures for automapped mailboxes and additional mailboxes.
+
+Signatures can be deployed for these mailboxes, but not set as default signature due to technical restrictions in Outlook.
+
+Up to a minute after starting Outlook, the detection of these mailboxes may fail as the corresponding registry keys are dynamically rebuilt by Outlook.
+
+Default value: `$false`
 # 3. Outlook signature path  
 The Outlook signature path is retrieved from the users registry, so the script is language independent.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 **Signatures and OOF messages can be:**
 - Generated from templates in DOCX or HTML file format  
 - Customized with a broad range of variables, including photos, from Active Directory and other sources  
-- Applied to all mailboxes (including shared mailboxes), specific mailbox groups or specific e-mail addresses, for every primary mailbox across all Outlook profiles  
+- Applied to all mailboxes (including shared mailboxes), specific mailbox groups or specific e-mail addresses, for every primary mailbox across all Outlook profiles (automapped and additional mailboxes are optional)  
 - Assigned time ranges within which they are valid  
 - Set as default signature for new e-mails, or for replies and forwards (signatures only)  
 - Set as default OOF message for internal or external recipients (OOF messages only)  
@@ -315,9 +315,11 @@ The registry setting does not allow for absolute paths, only for paths relative 
 
 If the relative path set in the registry would be a valid path but does not exist, the script creates it.  
 # 4. Mailboxes  
-The script only considers primary mailboxes, these are mailboxes added as separate accounts.
+The script only considers primary mailboxes per default, these are mailboxes added as separate accounts.
 
 This is the same way Outlook handles mailboxes from a signature perspective: Outlook can not handle signatures for non-primary mailboxes (added via "Open these additional mailboxes").
+
+Setting the parameter '`SignaturesForAutomappedAndAdditionalMailboxes`' to '`true`' allows the script to detect automapped and additional mailboxes. Signatures can be deployed for these types of mailboxes, but they can not be set as default signatures due to technical restrictions in Outlook.
 
 The script is created for Exchange environments. Non-Exchange mailboxes can not have OOF messages or group signatures, but common and mailbox specific signatures.  
 # 5. Group membership  
@@ -871,10 +873,11 @@ Fixing issues has priority over new features, of course.
 ## 16.19. How to deploy signatures for "Send As", "Send On Behalf" etc.?
 The script only considers primary mailboxes, these are mailboxes added as separate accounts. This is the same way Outlook handles mailboxes from a signature perspective: Outlook can not handle signatures for non-primary mailboxes (added via "Open these additional mailboxes").
 
+If you want to deploy signatures for non-primary mailboxes, sett the parameter '`SignaturesForAutomappedAndAdditionalMailboxes`' to '`true`' to allow the script to detect automapped and additional mailboxes. Signatures can be deployed for these types of mailboxes, but they can not be set as default signatures due to technical restrictions in Outlook.
+
 If you want to deploy signatures for
-- non-primary mailboxes,
 - mailboxes you don't add to Outlook but just use an assigned "Send As" or "Send on Behalf" right by choosing a different "From" address,
-- or distribution lists, for which you use an assigned "Send As" or "Send on Behalf" right by choosing a different "From" address,
+- distribution lists, for which you use an assigned "Send As" or "Send on Behalf" right by choosing a different "From" address,
 create a group or e-mail address specific signature, where the group or the e-mail address does not refer to the mailbox or distribution group the e-mail is sent from, but rather the user or group who has the right to send from this mailbox or distribution group.
 
 An example:

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ Please consider <a href="https://github.com/sponsors/GruberMarkus" target="_blan
   - [2.18. CreateRtfSignatures](#218-creatertfsignatures)
   - [2.19. CreateTxtSignatures](#219-createtxtsignatures)
   - [2.20. EmbedImagesInHtml](#220-embedimagesinhtml)
+  - [2.21. SignaturesForAutomappedAndAdditionalMailboxes](#221-signaturesforautomappedandadditionalmailboxes)
 - [3. Outlook signature path](#3-outlook-signature-path)
 - [4. Mailboxes](#4-mailboxes)
 - [5. Group membership](#5-group-membership)
@@ -299,7 +300,7 @@ Outlook 2013 and earlier can't handle these embedded images when composing HTML 
 When setting EmbedImagesInHtml to `$false`, consider setting the Outlook registry value "Send Pictures With Document" to 1 to ensure that images are sent to the recipient (see https://support.microsoft.com/en-us/topic/inline-images-may-display-as-a-red-x-in-outlook-704ae8b5-b9b6-d784-2bdf-ffd96050dfd6 for details).
 
 Default value: `$true`
-## SignaturesForAutomappedAndAdditionalMailboxes
+## 2.21. SignaturesForAutomappedAndAdditionalMailboxes
 Deploy signatures for automapped mailboxes and additional mailboxes.
 
 Signatures can be deployed for these mailboxes, but not set as default signature due to technical restrictions in Outlook.

--- a/docs/README.md
+++ b/docs/README.md
@@ -305,9 +305,7 @@ Deploy signatures for automapped mailboxes and additional mailboxes.
 
 Signatures can be deployed for these mailboxes, but not set as default signature due to technical restrictions in Outlook.
 
-Up to a minute after starting Outlook, the detection of these mailboxes may fail as the corresponding registry keys are dynamically rebuilt by Outlook.
-
-Default value: `$false`
+Default value: `$true`
 # 3. Outlook signature path  
 The Outlook signature path is retrieved from the users registry, so the script is language independent.
 

--- a/src/Set-OutlookSignatures.ps1
+++ b/src/Set-OutlookSignatures.ps1
@@ -2660,7 +2660,8 @@ function SetSignatures {
                                 }
                             }
                         } else {
-                            Remove-Item (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))") -Force -ErrorAction SilentlyContinue $image.removenode() | Out-Null
+                            Remove-Item (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))") -Force -ErrorAction SilentlyContinue
+                            $image.removenode() | Out-Null
                         }
                     }
                 }

--- a/src/Set-OutlookSignatures.ps1
+++ b/src/Set-OutlookSignatures.ps1
@@ -7,7 +7,7 @@ Centrally manage and deploy Outlook text signatures and Out of Office auto reply
 Signatures and OOF messages can be:
 - Generated from templates in DOCX or HTML file format
 - Customized with a broad range of variables, including photos, from Active Directory and other sources
-- Applied to all mailboxes (including shared mailboxes), specific mailbox groups or specific e-mail addresses, for every primary mailbox across all Outlook profiles
+- Applied to all mailboxes (including shared mailboxes), specific mailbox groups or specific e-mail addresses, for every primary mailbox across all Outlook profiles (automapped and additional mailboxes are optional)
 - Assigned time ranges within which they are valid
 - Set as default signature for new e-mails, or for replies and forwards (signatures only)
 - Set as default OOF message for internal or external recipients (OOF messages only)

--- a/src/Set-OutlookSignatures.ps1
+++ b/src/Set-OutlookSignatures.ps1
@@ -1913,7 +1913,7 @@ function main {
 
             # Delete photos from file system
             foreach ($VariableName in (('$CURRENTMAILBOXMANAGERPHOTO$', $CURRENTMAILBOXMANAGERPHOTOGUID) , ('$CURRENTMAILBOXPHOTO$', $CURRENTMAILBOXPHOTOGUID), ('$CURRENTUSERMANAGERPHOTO$', $CURRENTUSERMANAGERPHOTOGUID), ('$CURRENTUSERPHOTO$', $CURRENTUSERPHOTOGUID))) {
-                RemoveItemAlternativeRecurse -LiteralPath (((Join-Path -Path $script:tempDir -ChildPath ($VariableName[0] + $VariableName[1] + '.jpeg'))))
+                Remove-Item -LiteralPath (((Join-Path -Path $script:tempDir -ChildPath ($VariableName[0] + $VariableName[1] + '.jpeg')))) -Force -ErrorAction SilentlyContinue
                 $ReplaceHash.Remove($VariableName[0])
                 $ReplaceHash.Remove(($VariableName[0][-999..-2] -join '') + 'DELETEEMPTY$')
             }
@@ -2059,7 +2059,7 @@ function main {
                                             $x = (New-Guid).guid.tostring()
                                             ConvertToSingleFileHTML ((Join-Path -Path ($SignaturePaths[0]) -ChildPath ($TempOWASigFile + '.htm'))) (Join-Path -Path $script:tempDir -ChildPath $x)
                                             $hsHtmlSignature = (Get-Content -LiteralPath (Join-Path -Path $script:tempDir -ChildPath $x) -Encoding UTF8 -Raw).ToString()
-                                            RemoveItemAlternativeRecurse (Join-Path -Path $script:tempDir -ChildPath $x)
+                                            Remove-Item (Join-Path -Path $script:tempDir -ChildPath $x) -Force
                                         } else {
                                             $hsHtmlSignature = (Get-Content -LiteralPath ((Join-Path -Path ($SignaturePaths[0]) -ChildPath ($TempOWASigFile + '.htm'))) -Encoding UTF8 -Raw).ToString()
                                         }
@@ -2176,7 +2176,7 @@ function main {
 
                 # Delete temporary OOF files from file system
                 foreach ($FileName in ("$OOFInternalGUID OOFInternal", "$OOFExternalGUID OOFExternal")) {
-                    RemoveItemAlternativeRecurse (Join-Path -Path $script:tempDir -ChildPath ($FileName + '.*'))
+                    Remove-Item ((Join-Path -Path $script:tempDir -ChildPath ($FileName + '.*'))) -Force -ErrorAction SilentlyContinue
                 }
             }
         }
@@ -2630,7 +2630,7 @@ function SetSignatures {
                     if (($image.src -clike "*$($VariableName[0])*") -or ($image.alt -clike "*$($VariableName[0])*")) {
                         if ($null -ne $ReplaceHash[$VariableName[0]]) {
                             if ($EmbedImagesInHtml -eq $false) {
-                                RemoveItemAlternativeRecurse (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))")
+                                Remove-Item (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))") -Force -ErrorAction SilentlyContinue
                                 Copy-Item (Join-Path -Path $script:tempDir -ChildPath ($VariableName[0] + $VariableName[1] + '.jpeg')) (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$($VariableName[0]).jpeg") -Force
                                 $image.src = [System.Web.HttpUtility]::UrlDecode("$([System.IO.Path]::ChangeExtension($Signature.Value, '.files'))/$($VariableName[0]).jpeg")
                                 if ($image.alt) {
@@ -2648,8 +2648,7 @@ function SetSignatures {
                     } elseif (($image.src -clike "*$(($VariableName[0][-999..-2] -join '') + 'DELETEEMPTY$')*") -or ($image.alt -clike "*$(($VariableName[0][-999..-2] -join '') + 'DELETEEMPTY$')*")) {
                         if ($null -ne $ReplaceHash[$VariableName[0]]) {
                             if ($EmbedImagesInHtml -eq $false) {
-                                RemoveItemAlternativeRecurse (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))")
-                                Copy-Item (Join-Path -Path $script:tempDir -ChildPath ($VariableName[0] + $VariableName[1] + '.jpeg')) (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$($VariableName[0]).jpeg") -Force
+                                Remove-Item (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))") -Force -ErrorAction SilentlyContinue Copy-Item (Join-Path -Path $script:tempDir -ChildPath ($VariableName[0] + $VariableName[1] + '.jpeg')) (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$($VariableName[0]).jpeg") -Force
                                 $image.src = [System.Web.HttpUtility]::UrlDecode("$([System.IO.Path]::ChangeExtension($Signature.Value, '.files'))/$($VariableName[0]).jpeg")
                                 if ($image.alt) {
                                     $image.alt = $($image.alt).replace((($VariableName[0][-999..-2] -join '') + 'DELETEEMPTY$'), '')
@@ -2661,8 +2660,7 @@ function SetSignatures {
                                 }
                             }
                         } else {
-                            RemoveItemAlternativeRecurse (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))")
-                            $image.removenode() | Out-Null
+                            Remove-Item (Join-Path -Path (Split-Path $path) -ChildPath "$($pathGUID).files/$([System.IO.Path]::GetFileName(([System.Web.HttpUtility]::UrlDecode(($image.src -replace '^about:', '')))))") -Force -ErrorAction SilentlyContinue $image.removenode() | Out-Null
                         }
                     }
                 }
@@ -2967,14 +2965,14 @@ function SetSignatures {
 
         Write-Host "$Indent      Remove temporary files"
         foreach ($extension in ('.docx', '.htm', '.rtf', '.txt')) {
-            RemoveItemAlternativeRecurse -LiteralPath $([System.IO.Path]::ChangeExtension($path, $extension))
+            Remove-Item -LiteralPath $([System.IO.Path]::ChangeExtension($path, $extension)) -ErrorAction SilentlyContinue | Out-Null
         }
 
         Foreach ($file in @(Get-ChildItem -Path ("$($script:tempDir)\*" + [System.IO.Path]::GetFileNameWithoutExtension($path) + '*') -Directory).FullName) {
-            RemoveItemAlternativeRecurse -LiteralPath $file
+            Remove-Item -LiteralPath $file -Force -Recurse -ErrorAction SilentlyContinue
         }
 
-        RemoveItemAlternativeRecurse (Join-Path -Path (Split-Path $path) -ChildPath $([System.IO.Path]::ChangeExtension($signature.value, '.files')))
+        Remove-Item (Join-Path -Path (Split-Path $path) -ChildPath $([System.IO.Path]::ChangeExtension($signature.value, '.files'))) -Force -Recurse -ErrorAction SilentlyContinue
     }
 
     if ((-not $ProcessOOF)) {
@@ -3452,7 +3450,7 @@ function GraphGetUserPhoto($user) {
             $local:x = (Get-Content -LiteralPath $local:tempFile -Encoding Byte -Raw)
         }
 
-        RemoveItemAlternativeRecurse $local:tempFile
+        Remove-Item $local:tempFile -Force
     } catch {
     }
 
@@ -3678,12 +3676,12 @@ try {
 
     if ($script:dllPath) {
         Remove-Module -Name $([System.IO.Path]::GetFileNameWithoutExtension($script:dllpath)) -Force # Microsoft.Exchange.WebServices
-        RemoveItemAlternativeRecurse $script:dllPath
+        Remove-Item $script:dllPath -Force -ErrorAction SilentlyContinue
     }
 
     if ($script:msalPath) {
         Remove-Module -Name MSAL.PS -Force
-        RemoveItemAlternativeRecurse $script:msalPath
+        Remove-Item $script:msalPath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     Write-Host

--- a/src/Set-OutlookSignatures.ps1
+++ b/src/Set-OutlookSignatures.ps1
@@ -715,9 +715,10 @@ function main {
                 (Get-Process | Where-Object { $_.path -ieq $OutlookFilePath.FullName }) -and
                 ((New-TimeSpan -Start (Get-Process | Where-Object { $_.path -ieq $OutlookFilePath.FullName }).starttime).totalseconds -le 60)
             ) {
-                Start-Sleep -Seconds 1 
+                Write-Verbose 'Outlook is running. Wait until Outlook is no longer running or running for more than 60 seconds'
+                Start-Sleep -Seconds 1
             }
-            
+
             foreach ($OutlookProfile in $OutlookProfiles) {
                 foreach ($RegistryFolder in @(Get-ItemProperty "hkcu:\Software\Microsoft\Office\$($OutlookRegistryVersion)\Outlook\Profiles\$($OutlookProfile)\*" -ErrorAction SilentlyContinue | Where-Object { ($_.'0102663e') })) {
                 (@(ForEach ($char in @(($RegistryFolder.'0102663e' -join ',').Split(',', [System.StringSplitOptions]::RemoveEmptyEntries) | Where-Object { $_ -gt '0' })) { [char][int]"$($char)" }) -join '') -split "$([char]0x000C)" | ForEach-Object {

--- a/src/Set-OutlookSignatures.ps1
+++ b/src/Set-OutlookSignatures.ps1
@@ -295,7 +295,7 @@ Param(
 
     # Embed images in HTML
     [ValidateSet(1, 0, '1', '0', 'true', 'false', '$true', '$false', 'yes', 'no')]
-    $EmbedImagesInHtml = $true
+    $EmbedImagesInHtml = $true,
 
     # Deploy signatures for automapped mailboxes and additional mailboxes
     [ValidateSet(1, 0, '1', '0', 'true', 'false', '$true', '$false', 'yes', 'no')]
@@ -705,7 +705,7 @@ function main {
             Write-Host "    $($MailAddresses[-1])"
         }
 
-        if ($SignaturesForAutomappedAndAdditionalMailboxes){
+        if ($SignaturesForAutomappedAndAdditionalMailboxes) {
             foreach ($RegistryFolder in @(Get-ItemProperty "hkcu:\Software\Microsoft\Office\$OutlookRegistryVersion\Outlook\Profiles\*\*" -ErrorAction SilentlyContinue | Where-Object { ($_.'0102663e') })) {
                 (@(ForEach ($char in @(($RegistryFolder.'0102663e' -join ',').Split(',', [System.StringSplitOptions]::RemoveEmptyEntries) | Where-Object { $_ -gt '0' })) { [char][int]"$($char)" }) -join '') -split "$([char]0x000C)" | ForEach-Object {
                     if ($_ -match "(\S+@\S+\.\S+(?=/o=))(/o=[\S ]+(?=.{5}$([char]0x0002)$([char]0x0010)))") {

--- a/src/Set-OutlookSignatures.ps1
+++ b/src/Set-OutlookSignatures.ps1
@@ -2936,15 +2936,17 @@ function SetSignatures {
             for ($j = 0; $j -lt $MailAddresses.count; $j++) {
                 if ($MailAddresses[$j] -ieq $MailAddresses[$AccountNumberRunning]) {
                     if (-not $SimulateUser) {
-                        Write-Host "$Indent      Set signature as default for new messages"
-                        if ($script:CurrentUserDummyMailbox -ne $true) {
-                            if ($OutlookFileVersion -ge '16.0.0.0') {
-                                New-ItemProperty -Path $RegistryPaths[$j] -Name 'New Signature' -PropertyType String -Value ((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) -Force | Out-Null
+                        if ($RegistryPaths[$j] -ilike '*\9375CFF0413111d3B88A00104B2A6676\*') {
+                            Write-Host "$Indent      Set signature as default for new messages"
+                            if ($script:CurrentUserDummyMailbox -ne $true) {
+                                if ($OutlookFileVersion -ge '16.0.0.0') {
+                                    New-ItemProperty -Path $RegistryPaths[$j] -Name 'New Signature' -PropertyType String -Value ((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) -Force | Out-Null
+                                } else {
+                                    New-ItemProperty -Path $RegistryPaths[$j] -Name 'New Signature' -PropertyType Binary -Value ([byte[]](([System.Text.Encoding]::Unicode.GetBytes(((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) + "`0")))) -Force | Out-Null
+                                }
                             } else {
-                                New-ItemProperty -Path $RegistryPaths[$j] -Name 'New Signature' -PropertyType Binary -Value ([byte[]](([System.Text.Encoding]::Unicode.GetBytes(((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) + "`0")))) -Force | Out-Null
+                                $script:CurrentUserDummyMailboxDefaultSigNew = (($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.')
                             }
-                        } else {
-                            $script:CurrentUserDummyMailboxDefaultSigNew = (($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.')
                         }
                     } else {
                         Copy-Item -LiteralPath (Join-Path -Path ($SignaturePaths[0]) -ChildPath ((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + '.htm')) -Destination ((Join-Path -Path ((New-Item -ItemType Directory (Join-Path -Path ($SignaturePaths[0]) -ChildPath "$($MailAddresses[$AccountNumberRunning])\") -Force).fullname) -ChildPath 'Default New.htm')) -Force
@@ -2960,15 +2962,17 @@ function SetSignatures {
             for ($j = 0; $j -lt $MailAddresses.count; $j++) {
                 if ($MailAddresses[$j] -ieq $MailAddresses[$AccountNumberRunning]) {
                     if (-not $SimulateUser) {
-                        Write-Host "$Indent      Set signature as default for reply/forward messages"
-                        if ($script:CurrentUserDummyMailbox -ne $true) {
-                            if ($OutlookFileVersion -ge '16.0.0.0') {
-                                New-ItemProperty -Path $RegistryPaths[$j] -Name 'Reply-Forward Signature' -PropertyType String -Value ((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) -Force | Out-Null
+                        if ($RegistryPaths[$j] -ilike '*\9375CFF0413111d3B88A00104B2A6676\*') {
+                            Write-Host "$Indent      Set signature as default for reply/forward messages"
+                            if ($script:CurrentUserDummyMailbox -ne $true) {
+                                if ($OutlookFileVersion -ge '16.0.0.0') {
+                                    New-ItemProperty -Path $RegistryPaths[$j] -Name 'Reply-Forward Signature' -PropertyType String -Value ((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) -Force | Out-Null
+                                } else {
+                                    New-ItemProperty -Path $RegistryPaths[$j] -Name 'Reply-Forward Signature' -PropertyType Binary -Value ([byte[]](([System.Text.Encoding]::Unicode.GetBytes(((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) + "`0")))) -Force | Out-Null
+                                }
                             } else {
-                                New-ItemProperty -Path $RegistryPaths[$j] -Name 'Reply-Forward Signature' -PropertyType Binary -Value ([byte[]](([System.Text.Encoding]::Unicode.GetBytes(((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + $(if ($CurrentMailboxUseSignatureRoaming -eq $true) { " ($($MailAddresses[$AccountNumberRunning]))" })) + "`0")))) -Force | Out-Null
+                                $script:CurrentUserDummyMailboxDefaultSigReply = (($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.')
                             }
-                        } else {
-                            $script:CurrentUserDummyMailboxDefaultSigReply = (($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.')
                         }
                     } else {
                         Copy-Item -LiteralPath (Join-Path -Path ($SignaturePaths[0]) -ChildPath ((($Signature.value -split '\.' | Select-Object -SkipLast 1) -join '.') + '.htm')) -Destination ((Join-Path -Path ((New-Item -ItemType Directory (Join-Path -Path ($SignaturePaths[0]) -ChildPath "$($MailAddresses[$AccountNumberRunning])\") -Force).fullname) -ChildPath 'Default Reply-Forward.htm')) -Force


### PR DESCRIPTION
## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.3.0-alpha3" target="_blank">v3.3.0</a> - 2022-09-05
_Attention cloud mailbox users: Microsoft will make roaming signatures available in late 2022. See 'What about the roaming signatures feature announced by Microsoft?' in README for details and recommended preparation steps._
### Changed
- Use different method to delete files to avoid occassional OneDrive error "access to the cloud file is denied"
### Added
- The script now detects not only primary mailboxes configured in Outlook, but also automapped and additional mailboxes. This behavior can be disabled with the new parameter '`SignaturesForAutomappedAndAdditionalMailboxes`'. See '`README`' for details.