### PR TITLE
v3.5.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,8 +19,8 @@
 ## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.1" target="_blank">v3.5.1</a> - 2022-12-20
 _Attention cloud mailbox users: Microsoft actively enables roaming signatures in Exchange Online. See `'What about the roaming signatures feature in Exchange Online?'` in '`README`' for details, known problems and workarounds._
 ### Fixed
-- Use different code to determine Outlook and Word executable file bitness, as the .Net APIs used before seem to fail randomly with the latest Windows and .Net updates
-- Do not stop script when '`SignaturesForAutomappedAndAdditionalMailboxes`' is enabled and the Outlook file path can not be determined
+- Use different code to determine Outlook and Word executable file bitness, as the .Net APIs used before seem to fail randomly with the latest Windows and .Net updates (especially when using 32-bit PowerShell on 64-bit Windows)
+- Do not stop the script when '`SignaturesForAutomappedAndAdditionalMailboxes`' is enabled and the Outlook file path can not be determined
 
 ## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.0" target="_blank">v3.5.0</a> - 2022-12-19
 _Attention cloud mailbox users: Microsoft actively enables roaming signatures in Exchange Online. See `'What about the roaming signatures feature in Exchange Online?'` in '`README`' for details, known problems and workarounds._

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,10 +16,10 @@
 -->
 
 
-## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.1" target="_blank">v3.5.1</a> - YYYY-MM-DD
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.1" target="_blank">v3.5.1</a> - 2022-12-20
 _Attention cloud mailbox users: Microsoft actively enables roaming signatures in Exchange Online. See `'What about the roaming signatures feature in Exchange Online?'` in '`README`' for details, known problems and workarounds._
 ### Fixed
-- Use different code to determine Outlook and Word executable file bitness, as the corresponding .Net APIs seem to fail randomly 
+- Use different code to determine Outlook and Word executable file bitness, as the .Net APIs used before seem to fail randomly with the latest Windows and .Net updates
 - Do not stop script when '`SignaturesForAutomappedAndAdditionalMailboxes`' is enabled and the Outlook file path can not be determined
 
 ## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.0" target="_blank">v3.5.0</a> - 2022-12-19

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,12 @@
 -->
 
 
+## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.1" target="_blank">v3.5.1</a> - YYYY-MM-DD
+_Attention cloud mailbox users: Microsoft actively enables roaming signatures in Exchange Online. See `'What about the roaming signatures feature in Exchange Online?'` in '`README`' for details, known problems and workarounds._
+### Fixed
+- Use different code to determine Outlook and Word executable file bitness, as the corresponding .Net APIs seem to fail randomly 
+- Do not stop script when '`SignaturesForAutomappedAndAdditionalMailboxes`' is enabled and the Outlook file path can not be determined
+
 ## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.0" target="_blank">v3.5.0</a> - 2022-12-19
 _Attention cloud mailbox users: Microsoft actively enables roaming signatures in Exchange Online. See `'What about the roaming signatures feature in Exchange Online?'` in '`README`' for details, known problems and workarounds._
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -530,9 +530,10 @@ Per default, `'.\config\default replacement variables.ps1'` contains the followi
     - `$CURRENTUSERPHOTO$`: Photo from Active Directory, see "[11.1 Photos from Active Directory](#111-photos-from-active-directory)" for details  
     - `$CURRENTUSERPHOTODELETEEMPTY$`: Photo from Active Directory, see "[11.1 Photos from Active Directory](#111-photos-from-active-directory)" for details  
     - `$CURRENTUSEREXTATTR1$` to `$CURRENTUSEREXTATTR15$`: Exchange extension attributes 1 to 15  
-    - `$CURRENTUSERCOMPANY`: Company  
-    - `$CURRENTUSERMAILNICKNAME`: Alias (mailNickname)  
-    - `$CURRENTUSERDISPLAYNAME`: Display Name  
+    - `$CURRENTUSEROFFICE$`: Office room number (physicalDeliveryOfficeName)  
+    - `$CURRENTUSERCOMPANY$`: Company  
+    - `$CURRENTUSERMAILNICKNAME$`: Alias (mailNickname)  
+    - `$CURRENTUSERDISPLAYNAME$`: Display Name  
 - Manager of currently logged in user  
     - Same variables as logged in user, `$CURRENTUSERMANAGER[...]$` instead of `$CURRENTUSER[...]$`  
 - Current mailbox  


### PR DESCRIPTION
## <a href="https://github.com/GruberMarkus/Set-OutlookSignatures/releases/tag/v3.5.1" target="_blank">v3.5.1</a> - 2022-12-20
_Attention cloud mailbox users: Microsoft actively enables roaming signatures in Exchange Online. See `'What about the roaming signatures feature in Exchange Online?'` in '`README`' for details, known problems and workarounds._
### Fixed
- Use different code to determine Outlook and Word executable file bitness, as the .Net APIs used before seem to fail randomly with the latest Windows and .Net updates (especially when using 32-bit PowerShell on 64-bit Windows)
- Do not stop the script when '`SignaturesForAutomappedAndAdditionalMailboxes`' is enabled and the Outlook file path can not be determined
